### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -12,6 +12,7 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/Parameters.yml@r0
     with:
       name: pyEDAA.Launcher
+      python_version_list: "3.6 3.7 3.8 3.9 3.10"
 
   BuildTheDocs:
     uses: pyTooling/Actions/.github/workflows/BuildTheDocs.yml@r0

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Documentation](https://img.shields.io/website?longCache=true&style=flat-square&label=edaa-org.github.io%2FpyEDAA.Launcher&logo=GitHub&logoColor=fff&up_color=blueviolet&up_message=Read%20now%20%E2%9E%9A&url=https%3A%2F%2Fedaa-org.github.io%2FpyEDAA.Launcher%2Findex.html)](https://edaa-org.github.io/pyEDAA.Launcher/)
 [![Gitter](https://img.shields.io/badge/chat-on%20gitter-4db797.svg?longCache=true&style=flat-square&logo=gitter&logoColor=e8ecef)](https://gitter.im/hdl/community)  
 [![GitHub Workflow - Build and Test Status](https://img.shields.io/github/workflow/status/edaa-org/pyEDAA.Launcher/Pipeline/main?longCache=true&style=flat-square&label=Build%20and%20Test&logo=GitHub%20Actions&logoColor=FFFFFF)](https://GitHub.com/edaa-org/pyEDAA.Launcher/actions/workflows/Pipeline.yml)
+[![Codacy - Quality](https://img.shields.io/codacy/grade/83936550d5094383bb89bb117c0abbfe?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.Launcher)
 
 <!--
 [![Sourcecode License](https://img.shields.io/pypi/l/pyEDAA.Launcher?longCache=true&style=flat-square&logo=Apache&label=code)](LICENSE.md)
@@ -16,8 +17,7 @@
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyEDAA.Launcher?longCache=true&style=flat-square&logo=PyPI&logoColor=FBE072)
 
 [![Libraries.io status for latest release](https://img.shields.io/librariesio/release/pypi/pyEDAA.Launcher?longCache=true&style=flat-square&logo=Libraries.io&logoColor=fff)](https://libraries.io/github/edaa-org/pyEDAA.Launcher)
-[![Codacy - Quality](https://img.shields.io/codacy/grade/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.Launcher)
-[![Codacy - Coverage](https://img.shields.io/codacy/coverage/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.Launcher)
+[![Codacy - Coverage](https://img.shields.io/codacy/coverage/83936550d5094383bb89bb117c0abbfe?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pyEDAA.Launcher)
 [![Codecov - Branch Coverage](https://img.shields.io/codecov/c/github/edaa-org/pyEDAA.Launcher?longCache=true&style=flat-square&logo=Codecov)](https://codecov.io/gh/edaa-org/pyEDAA.Launcher)
 
 [![Dependent repos (via libraries.io)](https://img.shields.io/librariesio/dependent-repos/pypi/pyEDAA.Launcher?longCache=true&style=flat-square&logo=GitHub)](https://GitHub.com/edaa-org/pyEDAA.Launcher/network/dependents)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,16 +16,16 @@
 .. only:: html
 
    |  |SHIELD:svg:Launcher-github| |SHIELD:svg:Launcher-ghp-doc| |SHIELD:svg:Launcher-gitter|
-   |  |SHIELD:svg:Launcher-gha-test|
+   |  |SHIELD:svg:Launcher-gha-test| |SHIELD:svg:Launcher-codacy-quality|
 
-.. Disabled shields: |SHIELD:svg:Launcher-src-license| |SHIELD:svg:Launcher-doc-license| |SHIELD:svg:Launcher-pypi-tag| |SHIELD:svg:Launcher-pypi-status| |SHIELD:svg:Launcher-pypi-python| |SHIELD:svg:Launcher-lib-status| |SHIELD:svg:Launcher-codacy-quality| |SHIELD:svg:Launcher-codacy-coverage| |SHIELD:svg:Launcher-codecov-coverage| |SHIELD:svg:Launcher-lib-dep| |SHIELD:svg:Launcher-req-status| |SHIELD:svg:Launcher-lib-rank|
+.. Disabled shields: |SHIELD:svg:Launcher-src-license| |SHIELD:svg:Launcher-doc-license| |SHIELD:svg:Launcher-pypi-tag| |SHIELD:svg:Launcher-pypi-status| |SHIELD:svg:Launcher-pypi-python| |SHIELD:svg:Launcher-lib-status| |SHIELD:svg:Launcher-codacy-coverage| |SHIELD:svg:Launcher-codecov-coverage| |SHIELD:svg:Launcher-lib-dep| |SHIELD:svg:Launcher-req-status| |SHIELD:svg:Launcher-lib-rank|
 
 .. only:: latex
 
    |SHIELD:png:Launcher-github| |SHIELD:png:Launcher-ghp-doc| |SHIELD:png:Launcher-gitter|
-   |SHIELD:png:Launcher-gha-test|
+   |SHIELD:png:Launcher-gha-test| |SHIELD:png:Launcher-codacy-quality|
 
-.. Disabled shields: |SHIELD:png:Launcher-src-license| |SHIELD:png:Launcher-doc-license| |SHIELD:png:Launcher-pypi-tag| |SHIELD:png:Launcher-pypi-status| |SHIELD:png:Launcher-pypi-python| |SHIELD:png:Launcher-lib-status| |SHIELD:png:Launcher-codacy-quality| |SHIELD:png:Launcher-codacy-coverage| |SHIELD:png:Launcher-codecov-coverage| |SHIELD:png:Launcher-lib-dep| |SHIELD:png:Launcher-req-status| |SHIELD:png:Launcher-lib-rank|
+.. Disabled shields: |SHIELD:png:Launcher-src-license| |SHIELD:png:Launcher-doc-license| |SHIELD:png:Launcher-pypi-tag| |SHIELD:png:Launcher-pypi-status| |SHIELD:png:Launcher-pypi-python| |SHIELD:png:Launcher-lib-status| |SHIELD:png:Launcher-codacy-coverage| |SHIELD:png:Launcher-codecov-coverage| |SHIELD:png:Launcher-lib-dep| |SHIELD:png:Launcher-req-status| |SHIELD:png:Launcher-lib-rank|
 
 The pyEDAA.Launcher Documentation
 #################################

--- a/doc/shields.inc
+++ b/doc/shields.inc
@@ -74,21 +74,21 @@
    :target: https://GitHub.com/edaa-org/pyEDAA.Launcher/actions/workflows/Pipeline.yml
 
 .. # Codacy - quality
-.. |SHIELD:svg:Launcher-codacy-quality| image:: https://img.shields.io/codacy/grade/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=codacy
+.. |SHIELD:svg:Launcher-codacy-quality| image:: https://img.shields.io/codacy/grade/83936550d5094383bb89bb117c0abbfe?longCache=true&style=flat-square&logo=codacy
    :alt: Codacy - Quality
    :height: 22
    :target: https://www.codacy.com/gh/edaa-org/pyEDAA.Launcher
-.. |SHIELD:png:Launcher-codacy-quality| image:: https://raster.shields.io/codacy/grade/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=codacy
+.. |SHIELD:png:Launcher-codacy-quality| image:: https://raster.shields.io/codacy/grade/83936550d5094383bb89bb117c0abbfe?longCache=true&style=flat-square&logo=codacy
    :alt: Codacy - Quality
    :height: 22
    :target: https://www.codacy.com/gh/edaa-org/pyEDAA.Launcher
 
 .. # Codacy - coverage
-.. |SHIELD:svg:Launcher-codacy-coverage| image:: https://img.shields.io/codacy/coverage/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=codacy
+.. |SHIELD:svg:Launcher-codacy-coverage| image:: https://img.shields.io/codacy/coverage/83936550d5094383bb89bb117c0abbfe?longCache=true&style=flat-square&logo=codacy
    :alt: Codacy - Line Coverage
    :height: 22
    :target: https://www.codacy.com/gh/edaa-org/pyEDAA.Launcher
-.. |SHIELD:png:Launcher-codacy-coverage| image:: https://raster.shields.io/codacy/coverage/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=codacy
+.. |SHIELD:png:Launcher-codacy-coverage| image:: https://raster.shields.io/codacy/coverage/83936550d5094383bb89bb117c0abbfe?longCache=true&style=flat-square&logo=codacy
    :alt: Codacy - Line Coverage
    :height: 22
    :target: https://www.codacy.com/gh/edaa-org/pyEDAA.Launcher


### PR DESCRIPTION
# Changes

* ci/Params: override python_version_list, since 3.6 was deprecated in pyTooling/Actions.
* doc: update codacy shields.
